### PR TITLE
Allow ACD_ROOT to include spaces

### DIFF
--- a/mount-acd
+++ b/mount-acd
@@ -13,7 +13,7 @@ fi
 /usr/local/bin/acd_cli sync
 
 # Create the directory for media if non-exists
-/usr/local/bin/acd_cli mkdir -p $ACD_ROOT
+/usr/local/bin/acd_cli mkdir -p "$ACD_ROOT"
 
 # Mount acd in the foreground
 exec /usr/local/bin/acd_cli -d mount -i60 -fg /mnt/acd-encrypted

--- a/mount-acd-encfs
+++ b/mount-acd-encfs
@@ -13,4 +13,4 @@ done
 echo "Acd mounted - mounting encfs on top"
 
 # Mount
-exec /usr/bin/encfs -f --extpass='/bin/echo ${ENCFS_PASS}' /mnt/acd-encrypted/${ACD_ROOT} /mnt/acd-decrypted
+exec /usr/bin/encfs -f --extpass='/bin/echo ${ENCFS_PASS}' "/mnt/acd-encrypted/${ACD_ROOT}" /mnt/acd-decrypted

--- a/upload-cron
+++ b/upload-cron
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Write crontab file
-echo "${UPLOAD_INTERVAL} acdcli upload -o /mnt/local-encrypted/* ${ACD_ROOT}" > /etc/cron.d/uploads
+echo "${UPLOAD_INTERVAL} acdcli upload -o /mnt/local-encrypted/* '${ACD_ROOT}'" > /etc/cron.d/uploads
 echo "${UPLOAD_INTERVAL} find /mnt/local-decrypted/* -ctime +${LOCAL_DAYS} -exec rm -f {} \;" >> /etc/cron.d/uploads
 
 # Load cron and switch process


### PR DESCRIPTION
Currently the ACD_ROOT may not include any spaces which is in my case a real problem. 